### PR TITLE
Add avy-action-ispell to avy.el

### DIFF
--- a/avy.el
+++ b/avy.el
@@ -522,6 +522,17 @@ Set `avy-style' according to COMMMAND as well."
    (kill-region pt (point))
    (just-one-space))
   (message "Killed: %s" (current-kill 0)))
+  
+(defun avy-action-ispell (pt)
+  "Auto correct word at PT."
+  (save-excursion
+    (goto-char pt)
+    (if (looking-at-p "\\b")
+        (ispell-word)
+      (progn
+        (backward-word)
+        (when (looking-at-p "\\b")
+          (ispell-word))))))
 
 (defun avy--process (candidates overlay-fn)
   "Select one of CANDIDATES using `avy-read'.


### PR DESCRIPTION
Thank you so much for creating avy; It has been really fun to use and I thought I should give back in the most natural way. So here is my addition, a convenience  function (to add to avy-dispatch-alist) which makes spelling check less of a chore. The point should return back to where it was after spelling check is complete. Please let me know if this is a worthy addition. Thanks again!

Regards,

Emmanuel Denloye-Ito 
